### PR TITLE
Launch configuration sim time

### DIFF
--- a/config/launch_param.yaml
+++ b/config/launch_param.yaml
@@ -1,0 +1,1 @@
+use_sim_time: true

--- a/launch/cartographer.launch.py
+++ b/launch/cartographer.launch.py
@@ -61,7 +61,7 @@ def generate_launch_description():
         executable='occupancy_grid_node',
         name='occupancy_grid_node',
         parameters=[{
-            'use_sim_time': False,
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
             # Add other parameters specific to the occupancy grid node as needed
             'resolution': 0.05,  # Example parameter for grid resolution
         }],

--- a/launch/cartographer.launch.py
+++ b/launch/cartographer.launch.py
@@ -13,6 +13,10 @@ def generate_launch_description():
     assets_dir = os.path.join(package_dir,'assets')
     config_file_path = os.path.join(package_dir,'config')
     map_file_path = os.path.join(assets_dir,'map.pbstream')
+
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time', default_value='true',
+        description='Use simulation time')
     
     finish_trajectory_cmd = [
         'ros2', 'service', 'call', '/finish_trajectory',
@@ -31,7 +35,7 @@ def generate_launch_description():
         executable='cartographer_node',
         name='cartographer_node',
         parameters=[{
-            'use_sim_time': False,  # Example parameter
+            'use_sim_time': LaunchConfiguration('use_sim_time'),  # Example parameter
             # Add other parameters as needed
         }],
         arguments=[
@@ -41,7 +45,7 @@ def generate_launch_description():
         ],
         remappings=[
             ('/points2', '/merged/point_cloud'),
-            # ('/odom', '/zed/zed_node/odom'),
+            ('/odom', '/zed/zed_node/odom'),
             ('/imu', '/zed/zed_node/imu/data'),
             # ('/points2_1','/lidar/points_hz'),
             # ('/points2_2','/lidar/points_vt'),
@@ -81,7 +85,7 @@ def generate_launch_description():
 
 
     return LaunchDescription([
-        # record_bag_arg,
+        use_sim_time_arg,
         cartographer_node,
         occupancy_grid_node,
         # finish_trajectory,

--- a/launch/drone.launch.py
+++ b/launch/drone.launch.py
@@ -1,5 +1,5 @@
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription,ExecuteProcess
+from launch.actions import IncludeLaunchDescription,ExecuteProcess,DeclareLaunchArgument
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir
 from ament_index_python.packages import get_package_share_directory
@@ -7,25 +7,24 @@ from launch_ros.actions import Node
 import os
 import datetime
 
+
 def generate_launch_description():
     sensor_integration_dir_launch = os.path.join(
         get_package_share_directory('sensor_integration_suite'),
         'launch'
     )
     package_dir = get_package_share_directory('drone_bringup')
-    #Define to assets dir
     assets_dir = os.path.join(package_dir,'assets')
+    config_dir = os.path.join(package_dir,'config')
     now = datetime.datetime.now()
     bag_file_name = now.strftime("%Y%m%d%H%M%S")
-
     bag_file_path = os.path.join(assets_dir,'recorded_data_'+ bag_file_name +'.bag')
-    # Define a launch argument to control bag recording
-    # record_bag_arg = DeclareLaunchArgument(
-    #     'record_bag', default_value='true',
-    #     description='Set to "true" to record a bag file during this launch session.'
-    # )
+
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time', default_value='true',
+        description='Use simulation time')   
     
-    # Use the launch argument value to conditionally start bag recording
+    # Record Bag file
     record_bag = ExecuteProcess(
         cmd=[  'ros2', 'bag', 'record', '-o',
                 bag_file_path,
@@ -34,17 +33,21 @@ def generate_launch_description():
             ],
             output='screen'
     )
+    robot_state_publisher = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/rsp.launch.py']),
+        launch_arguments={'use_sim_time': LaunchConfiguration('use_sim_time')}.items(),
+    )
+    sensor_integration_suite = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/sensor_integration.launch.py']),
+        launch_arguments={'use_sim_time': LaunchConfiguration('use_sim_time')}.items(),
+    )
 
 
     return LaunchDescription([
+        use_sim_time_arg,
         record_bag,
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/rsp.launch.py'])
-        ),
-
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([sensor_integration_dir_launch, '/sensor_integration.launch.py'])
-        )
+        robot_state_publisher,
+        sensor_integration_suite
         # IncludeLaunchDescription(
         #     PythonLaunchDescriptionSource([drone_launch_dir, '/rtabmap.launch.py'])
         # )

--- a/launch/drone.launch.py
+++ b/launch/drone.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
     bag_file_path = os.path.join(assets_dir,'recorded_data_'+ bag_file_name +'.bag')
 
     use_sim_time_arg = DeclareLaunchArgument(
-        'use_sim_time', default_value='true',
+        'use_sim_time', default_value='false',
         description='Use simulation time')   
     
     

--- a/launch/drone.launch.py
+++ b/launch/drone.launch.py
@@ -4,6 +4,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import Node
+from launch.actions import LogInfo
 import os
 import datetime
 
@@ -50,8 +51,9 @@ def generate_launch_description():
     gazebo_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([gazebo_ros_launch_dir,'/gazebo.launch.py'])
     )
-    launch_list = []
+    launch_list = [use_sim_time_arg]
     if(LaunchConfiguration('use_sim_time')):
+        LogInfo(msg=["This is a message printed from the launch file!",LaunchConfiguration('use_sim_time')])
         launch_list.append(gazebo_launch)
         launch_list.append(record_bag)
     launch_list.append(robot_state_publisher)

--- a/launch/drone.launch.py
+++ b/launch/drone.launch.py
@@ -1,7 +1,7 @@
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription,ExecuteProcess,DeclareLaunchArgument
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir
+from launch.substitutions import LaunchConfiguration
 from ament_index_python.packages import get_package_share_directory
 from launch_ros.actions import Node
 import os
@@ -19,7 +19,7 @@ def generate_launch_description():
     )
     package_dir = get_package_share_directory('drone_bringup')
     assets_dir = os.path.join(package_dir,'assets')
-    config_dir = os.path.join(package_dir,'config')
+    package_launch_dir = os.path.join(package_dir,'launch')
     now = datetime.datetime.now()
     bag_file_name = now.strftime("%Y%m%d%H%M%S")
     bag_file_path = os.path.join(assets_dir,'recorded_data_'+ bag_file_name +'.bag')
@@ -39,7 +39,7 @@ def generate_launch_description():
             output='screen'
     )
     robot_state_publisher = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/rsp.launch.py']),
+        PythonLaunchDescriptionSource([package_launch_dir, '/rsp.launch.py']),
         launch_arguments={'use_sim_time': LaunchConfiguration('use_sim_time')}.items(),
     )
     sensor_integration_suite = IncludeLaunchDescription(

--- a/launch/drone.launch.py
+++ b/launch/drone.launch.py
@@ -13,6 +13,10 @@ def generate_launch_description():
         get_package_share_directory('sensor_integration_suite'),
         'launch'
     )
+    gazebo_ros_launch_dir = os.path.join(
+        get_package_share_directory('gazebo_ros'),
+        'launch'
+    )
     package_dir = get_package_share_directory('drone_bringup')
     assets_dir = os.path.join(package_dir,'assets')
     config_dir = os.path.join(package_dir,'config')
@@ -23,6 +27,7 @@ def generate_launch_description():
     use_sim_time_arg = DeclareLaunchArgument(
         'use_sim_time', default_value='true',
         description='Use simulation time')   
+    
     
     # Record Bag file
     record_bag = ExecuteProcess(
@@ -42,14 +47,14 @@ def generate_launch_description():
         launch_arguments={'use_sim_time': LaunchConfiguration('use_sim_time')}.items(),
     )
 
+    gazebo_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([gazebo_ros_launch_dir,'/gazebo.launch.py'])
+    )
+    launch_list = []
+    if(LaunchConfiguration('use_sim_time')):
+        launch_list.append(gazebo_launch)
+        launch_list.append(record_bag)
+    launch_list.append(robot_state_publisher)
+    launch_list.append(sensor_integration_suite)
 
-    return LaunchDescription([
-        use_sim_time_arg,
-        record_bag,
-        robot_state_publisher,
-        sensor_integration_suite
-        # IncludeLaunchDescription(
-        #     PythonLaunchDescriptionSource([drone_launch_dir, '/rtabmap.launch.py'])
-        # )
-
-    ])
+    return LaunchDescription(launch_list)

--- a/launch/drone.launch.py
+++ b/launch/drone.launch.py
@@ -62,8 +62,8 @@ def generate_launch_description():
         robot_state_publisher,# Add robot_state_publisher action here
         sensor_integration_suite# Add sensor_integration_suite action here
     ]
-    return LaunchDescription(
+    return LaunchDescription([
         use_sim_time_arg,
         conditional_actions,
-        *always_included_actions
+        *always_included_actions]
     )

--- a/launch/drone.launch.py
+++ b/launch/drone.launch.py
@@ -53,7 +53,7 @@ def generate_launch_description():
     )
     launch_list = [use_sim_time_arg]
     if(LaunchConfiguration('use_sim_time')):
-        LogInfo(msg=["This is a message printed from the launch file!",LaunchConfiguration('use_sim_time')])
+        launch_list.append(LogInfo(msg=["This is a message printed from the launch file!",LaunchConfiguration('use_sim_time')]))
         launch_list.append(gazebo_launch)
         launch_list.append(record_bag)
     launch_list.append(robot_state_publisher)

--- a/launch/drone.launch.py
+++ b/launch/drone.launch.py
@@ -38,7 +38,7 @@ def generate_launch_description():
         launch_arguments={'use_sim_time': LaunchConfiguration('use_sim_time')}.items(),
     )
     sensor_integration_suite = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([ThisLaunchFileDir(), '/sensor_integration.launch.py']),
+        PythonLaunchDescriptionSource([sensor_integration_dir_launch, '/sensor_integration.launch.py']),
         launch_arguments={'use_sim_time': LaunchConfiguration('use_sim_time')}.items(),
     )
 

--- a/launch/rsp.launch.py
+++ b/launch/rsp.launch.py
@@ -1,5 +1,6 @@
 import os
 from ament_index_python.packages import get_package_share_directory
+from launch.actions import DeclareLaunchArgument
 from launch import LaunchDescription
 from launch_ros.actions import Node
 import xacro
@@ -15,18 +16,22 @@ def generate_launch_description():
     # Use xacro to process the file
     xacro_file = os.path.join(get_package_share_directory(pkg_name),file_subpath)
     robot_description_raw = xacro.process_file(xacro_file).toxml()
-
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time', default_value='true',
+        description='Use simulation time')
 
     # Configure the node
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
         output='screen',
-        parameters=[{'robot_description': robot_description_raw}] # add other parameters here if required
+        parameters=[{'robot_description': robot_description_raw,
+                     'use_sim_time':LaunchDescription('use_sim_time')}] # add other parameters here if required
     )
 
 
     # Run the node
     return LaunchDescription([
+        use_sim_time_arg,
         node_robot_state_publisher
     ])

--- a/launch/rsp.launch.py
+++ b/launch/rsp.launch.py
@@ -1,6 +1,7 @@
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch import LaunchDescription
 from launch_ros.actions import Node
 import xacro
@@ -26,7 +27,7 @@ def generate_launch_description():
         executable='robot_state_publisher',
         output='screen',
         parameters=[{'robot_description': robot_description_raw,
-                     'use_sim_time':LaunchDescription('use_sim_time')}] # add other parameters here if required
+                     'use_sim_time':LaunchConfiguration('use_sim_time')}] # add other parameters here if required
     )
 
 

--- a/launch/rtabmap.launch.py
+++ b/launch/rtabmap.launch.py
@@ -5,7 +5,6 @@ from launch.actions import DeclareLaunchArgument
 
 def generate_launch_description():
     # Launch arguments to allow for custom configurations
-    use_sim_time = LaunchConfiguration('use_sim_time', default='false')
 
     return LaunchDescription([
         # Declare launch arguments
@@ -21,7 +20,6 @@ def generate_launch_description():
             output='screen',
             parameters=[{
                 'rtabmap_args': "--delete_db_on_start",
-                'use_sim_time': use_sim_time,
                 'frame_id': 'base_link',
                 'odom_frame_id': 'odom',
                 'subscribe_scan': True,
@@ -39,8 +37,7 @@ def generate_launch_description():
                 ('left/camera_info', '/zed/zed_node/left/camera_info'),
                 ('right/camera_info', '/zed/zed_node/right/camera_info'),
                 ('odom', '/zed/zed_node/odom')
-            ],
-            arguments=['-d', LaunchConfiguration('use_sim_time')]
+            ]
         ),
         Node(
             package='rtabmap_viz',

--- a/launch/rtabmap.launch.py
+++ b/launch/rtabmap.launch.py
@@ -27,6 +27,7 @@ def generate_launch_description():
                 'subscribe_scan': True,
                 'subscribe_stereo': True,
                 'approx_sync': True,
+                'use_sim_time': LaunchConfiguration('use_sim_time')
                 # Additional RTAB-Map parameters...
             }],
             remappings=[
@@ -46,7 +47,8 @@ def generate_launch_description():
             executable='rtabmap_viz',
             name='rtabmapviz',
             output='screen',
-            parameters=[{'Rtabmapviz/ShowRtabmapviz': True}]
+            parameters=[{'Rtabmapviz/ShowRtabmapviz': True,
+                         'use_sim_time':LaunchConfiguration('use_sim_time')}]
         ),
 
         # Add other necessary nodes (like odometry)


### PR DESCRIPTION
Added the use_sim_time to the launch file, you can now launch the drone_bringup with use_sim_time parameter. 
In drone_bringup.launch.py file when use_sim_time is set to true it starts recording the data as bag file and also stars gazebo for the clock topic